### PR TITLE
webpack-cli 2.0.15 npm run build报错

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "react-addons-perf": "^15.4.2",
     "style-loader": "^0.20.3",
     "webpack": "^4.5.0",
-    "webpack-cli": "^2.0.14",
+    "webpack-cli": "2.0.14",
     "ykit-config-antd": "^1.2.0"
   }
 }


### PR DESCRIPTION
webpack-cli 2.0.15报错，锁定版本2.0.14，npm run build正常