### PR TITLE
UI组件库antd发包时带上了, 不应该带上

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "build": "webpack"
   },
   "dependencies": {
-    "antd": "^3.1.6",
     "generate-schema": "^2.6.0",
     "moox": "^1.0.2",
     "react-redux": "^5.0.6",
@@ -17,6 +16,7 @@
     "brace": "^0.10.0"
   },
   "devDependencies": {
+    "antd": "^3.1.6",
     "autoprefixer": "^7.2.1",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",


### PR DESCRIPTION
antd和react应该是一样的，应该是与外部的一致，不应该发包的时候带上node_modules/antd

## 出现问题
现在这种模式，导致编辑器的antd版本和yapi的antd版本不一致，icon出现2个
![image](https://user-images.githubusercontent.com/15716269/53867579-1ca92b00-402f-11e9-9915-d10817a1e4de.png)

## 解决方案
把antd放在devDependencies，antd就不会让依赖包带上，node_modules/antd
![image](https://user-images.githubusercontent.com/15716269/53867945-d6a09700-402f-11e9-8c9b-a5d021016e1d.png)
