### PR TITLE
antd 跟yapi版本不一致，导致icon渲染2个

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "webpack"
   },
   "dependencies": {
-    "antd": "^3.1.6",
+    "antd": "3.2.2",
     "generate-schema": "^2.6.0",
     "moox": "^1.0.2",
     "react-redux": "^5.0.6",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15716269/53870922-1ec2b800-4036-11e9-83d3-ed0507fe8ec5.png)

版本保持一致后，icon问题解决