### PR TITLE
添加更多的控制能力，通过组件初始化参数传入

### DIFF
--- a/package/App.js
+++ b/package/App.js
@@ -274,9 +274,12 @@ class jsonSchema extends React.Component {
 
     return (
       <div className="json-schema-react-editor">
-        <Button className="import-json-button" type="primary" onClick={this.showModal}>
-          {LocalProvider('import_json')}
-        </Button>
+        {
+          !this.props.Model.__controlHideElements.includes('import-json') &&
+          <Button className="import-json-button" type="primary" onClick={this.showModal}>
+            {LocalProvider('import_json')}
+          </Button>
+        }
         <Modal
           maskClosable={false}
           visible={visible}
@@ -407,6 +410,7 @@ class jsonSchema extends React.Component {
                   className="type-select-style"
                   onChange={e => this.changeType(`type`, e)}
                   value={schema.type || 'object'}
+                  disabled={this.props.Model.__controlLockRoot}
                 >
                   {SCHEMA_TYPE.map((item, index) => {
                     return (
@@ -428,7 +432,7 @@ class jsonSchema extends React.Component {
               )}
               <Col span={this.props.isMock ? 4 : 5} className="col-item col-item-desc">
                 <Input
-                  addonAfter={
+                  addonAfter={!this.props.Model.__controlHideElements.includes('description-addon') &&
                     <Icon
                       type="edit"
                       onClick={() =>
@@ -439,14 +443,15 @@ class jsonSchema extends React.Component {
                   placeholder={'description'}
                   value={schema.description}
                   onChange={e => this.changeValue(['description'], e.target.value)}
+                  disabled={this.props.Model.__controlLockRoot}
                 />
               </Col>
               <Col span={3} className="col-item col-item-setting">
-                <span className="adv-set" onClick={() => this.showAdv([], this.props.schema)}>
+                {!this.props.Model.__controlHideElements.includes('advanced-settings') && <span className="adv-set" onClick={() => this.showAdv([], this.props.schema)}>
                   <Tooltip placement="top" title={LocalProvider('adv_setting')}>
                     <Icon type="setting" />
                   </Tooltip>
-                </span>
+                </span>}
                 {schema.type === 'object' ? (
                   <span onClick={() => this.addChildField('properties')}>
                     <Tooltip placement="top" title={LocalProvider('add_child_node')}>

--- a/package/components/SchemaComponents/SchemaJson.js
+++ b/package/components/SchemaComponents/SchemaJson.js
@@ -394,7 +394,7 @@ class SchemaItem extends PureComponent {
 
           <Col span={this.context.isMock ? 4 : 5} className="col-item col-item-desc">
             <Input
-              addonAfter={<Icon type="edit" onClick={() => this.handleShowEdit('description')} />}
+              addonAfter={!this.context.Model.__controlHideElements.includes('description-addon') && <Icon type="edit" onClick={() => this.handleShowEdit('description')} />}
               placeholder={LocaleProvider('description')}
               value={value.description}
               onChange={this.handleChangeDesc}
@@ -403,11 +403,13 @@ class SchemaItem extends PureComponent {
 
           
           <Col span={3} className="col-item col-item-setting">
-            <span className="adv-set" onClick={this.handleShowAdv}>
-              <Tooltip placement="top" title={LocaleProvider('adv_setting')}>
-                <Icon type="setting" />
-              </Tooltip>
-            </span>
+            {!this.context.Model.__controlHideElements.includes('advanced-settings') &&
+              <span className="adv-set" onClick={this.handleShowAdv}>
+                <Tooltip placement="top" title={LocaleProvider('adv_setting')}>
+                  <Icon type="setting" />
+                </Tooltip>
+              </span>
+            }
             <span className="delete-item" onClick={this.handleDeleteItem}>
               <Icon type="close" className="close" />
             </span>

--- a/package/index.js
+++ b/package/index.js
@@ -23,6 +23,19 @@ module.exports = (config = {})=>{
     Model.__jsonSchemaMock = config.mock
   }
 
+  if(config.lockRoot) {
+    // 根节点属性不可修改
+    Model.__controlLockRoot = config.lockRoot
+  }
+
+  // 支持: 'description-addon', 'advanced-settings', 'import-json'
+  if(config.hideElements) {
+    // 隐藏一些元素
+    Model.__controlHideElements = config.hideElements
+  } else {
+    Model.__controlHideElements = []
+  }
+
   
 
   const store = Model.getStore();


### PR DESCRIPTION
lockRoot: 根节点不可编辑
hideElements: 隐藏部分元素('description-addon', 'advanced-settings', 'import-json')

/// 有些场景，不需要这种复杂编辑能力，隐藏一些元素可以让使用更加简单。